### PR TITLE
Add plugin to enforce brace styling and enable strict rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,22 +13,25 @@ module.exports = {
       2,
       {
         'SwitchCase': 1,
-        'ignoredNodes': ['CallExpression']
+        'ignoredNodes': ['CallExpression', 'ForStatement']
       }
     ],
     'linebreak-style': [
       'error',
       'unix'
     ],
+    'quotes': [
+      'warn',
+      'single'
+    ],
     'func-call-spacing': [
-      'warn', 'never'
+      'off', 'never'
     ],
     'no-prototype-builtins': 'off',
-    'quotes': ['warn', 'single', 'avoid-escape'],
     'no-unused-vars': ['warn', { 'vars': 'all', 'args': 'none', 'ignoreRestSiblings': false }],
     'no-empty': [ 'warn' ],
     'no-trailing-spaces': [
-      'warn', {
+      'off', {
         skipBlankLines: true,
         ignoreComments: true
       }
@@ -88,7 +91,19 @@ module.exports = {
     'no-label-var':             [ 'error' ],
     'radix':                    [ 'error' ],
     'no-self-compare':          [ 'error' ],
-    'no-implicit-coercion':     [ 'error' ],
+    'require-await':            [ 'error'],
+    'require-yield':            [ 'error' ],
+    'no-promise-executor-return':       [ 'off' ],
+    'no-template-curly-in-string':      [ 'warn' ],
+    'no-unmodified-loop-condition':     [ 'warn' ],
+    'no-unused-private-class-members':  [ 'warn' ],
+    'no-implicit-coercion': [1, {
+      disallowTemplateShorthand: false,
+      boolean: true,
+      number: true,
+      string: true,
+      allow: ['!!'] /* really only want to allow if(x) and if(!x) but not if(!!x) */
+    }],
     'distributive/brace-style': 'warn'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@
  * @type {import('eslint').Linter.Config}
  */
 // eslint-disable-next-line no-undef
+/* eslint strict: 'off' */
 module.exports = {
   'env': {
     'browser': true,
@@ -12,7 +13,7 @@ module.exports = {
   'extends': 'eslint:recommended',
   'parserOptions': {
     'ecmaVersion': 13,
-    sourceType: 'script',
+    'sourceType': 'script',
   },
   globals: {
     dcpConfig: true
@@ -117,6 +118,7 @@ module.exports = {
       string: true,
       allow: ['!!'] /* really only want to allow if(x) and if(!x) but not if(!!x) */
     }],
+    'strict':                   [ 'error', 'safe' ],
     'distributive/brace-style': 'warn'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,6 +119,6 @@ module.exports = {
       allow: ['!!'] /* really only want to allow if(x) and if(!x) but not if(!!x) */
     }],
     'strict':                   [ 'error', 'safe' ],
-    'distributive/brace-style': 'warn'
+    '@distributive/brace-style': 'warn'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
     dcpConfig: true
   },
   'plugins': [
-    'distributive'
+    '@distributive'
   ],
   'rules': {
     'indent': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@
 // eslint-disable-next-line no-undef
 module.exports = {
   'extends': 'eslint:recommended',
+  'plugins': [
+    'distributive'
+  ],
   'rules': {
     'indent': [
       'warn',
@@ -86,5 +89,6 @@ module.exports = {
     'radix':                    [ 'error' ],
     'no-self-compare':          [ 'error' ],
     'no-implicit-coercion':     [ 'error' ],
+    'distributive/brace-style': 'warn'
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,20 @@
  */
 // eslint-disable-next-line no-undef
 module.exports = {
+  'env': {
+    'browser': true,
+    'commonjs': true,
+    'es2021': true,
+    'node': true
+  },
   'extends': 'eslint:recommended',
+  'parserOptions': {
+    'ecmaVersion': 13,
+    sourceType: 'script',
+  },
+  globals: {
+    dcpConfig: true
+  },
   'plugins': [
     'distributive'
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,8 @@
+'use strict';
+
 /**
  * @type {import('eslint').Linter.Config}
  */
-// eslint-disable-next-line no-undef
-/* eslint strict: 'off' */
 module.exports = {
   'env': {
     'browser': true,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# KDS JavaScript Style Guide
+# Distributive JavaScript Style Guide
 
-This document is an incomplete draft of a proposed style guide for JavaScript written at KDS.
+This document is an incomplete draft of a proposed style guide for JavaScript written at Distributive.
 
-Last Updated: July 2021
+Last Updated: June 2023
 
 ## Cardinal Rules
 
@@ -86,7 +86,7 @@ if ((a + b) > (c + d))
 
  - File names are `kebab-case`.
  - Variable names and object property names are `camelCase`
- - Acronyms are treated like words; if we had named `window.XMLHttpRequest` at KDS, it would have been called `window.xmlHttpRequest`.
+ - Acronyms are treated like words; if we had named `window.XMLHttpRequest` at Distributive, it would have been called `window.xmlHttpRequest`.
  - Class names are `CamelCaseWithUppercaseFirstCharacter`
  - Function arguments that are unused should start with _
  - "private" API or object properties should start with __
@@ -112,7 +112,7 @@ Upper case and lower case are each two words.
 
 ## Braces
 
-There are two bracing styles in use simultaneously throughout the KDS JS Style:
+There are two bracing styles in use simultaneously throughout the Distributive JS Style:
 
  - Lexical braces: always alone on a line. "Allman Style"
  - Literal braces: never alone on a line; closing braces always followed by  `,`, `)`, or `;`. "1tbs Style".

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,13 @@
       "name": "@distributive/eslint-config",
       "version": "1.0.3",
       "license": "MIT",
-      "devDependencies": {
-        "eslint-plugin-distributive": "github:Distributive-Network/eslint-plugin-distributive"
-      },
       "engines": {
         "node": ">=16",
         "npm": ">=7"
       },
       "peerDependencies": {
-        "eslint": ">=8"
+        "eslint": ">=8",
+        "eslint-plugin-distributive": "github:Distributive-Network/eslint-plugin-distributive"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -405,8 +403,8 @@
     "node_modules/eslint-plugin-distributive": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/Distributive-Network/eslint-plugin-distributive.git#7582884b5a51348282264904118d9dbfd3e1853d",
-      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "requireindex": "^1.2.0"
       },
@@ -961,7 +959,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@distributive/eslint-config",
       "version": "1.0.3",
       "license": "MIT",
+      "devDependencies": {
+        "eslint-plugin-distributive": "github:Distributive-Network/eslint-plugin-distributive"
+      },
       "engines": {
         "node": ">=16",
         "npm": ">=7"
@@ -397,6 +400,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-distributive": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/Distributive-Network/eslint-plugin-distributive.git#7582884b5a51348282264904118d9dbfd3e1853d",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "requireindex": "^1.2.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
       }
     },
     "node_modules/eslint-scope": {
@@ -938,6 +956,15 @@
         }
       ],
       "peer": true
+    },
+    "node_modules/requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {},
   "peerDependencies": {
-    "eslint": ">=8",
-    "eslint-plugin-distributive": "@distributive/eslint-plugin"
+    "@distributive/eslint-plugin": "^1.0.0",
+    "eslint": ">=8"
   },
   "engines": {
     "node": ">=16",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   ],
   "scripts": {},
   "peerDependencies": {
-    "eslint": ">=8"
+    "eslint": ">=8",
+    "eslint-plugin-distributive": "github:Distributive-Network/eslint-plugin-distributive"
   },
   "engines": {
     "node": ">=16",
@@ -32,8 +33,5 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
-  },
-  "devDependencies": {
-    "eslint-plugin-distributive": "github:Distributive-Network/eslint-plugin-distributive"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "devDependencies": {
+    "eslint-plugin-distributive": "github:Distributive-Network/eslint-plugin-distributive"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {},
   "peerDependencies": {
     "eslint": ">=8",
-    "eslint-plugin-distributive": "github:Distributive-Network/eslint-plugin-distributive"
+    "eslint-plugin-distributive": "@distributive/eslint-plugin"
   },
   "engines": {
     "node": ">=16",


### PR DESCRIPTION
This PR adds the newly developed, fresh out of the oven [eslint-plugin-distributive](https://github.com/Distributive-Network/eslint-plugin-distributive) which contains a custom rule that can warn / enforce our custom bracing style guidelines.

Also a quick fix to refactor references of KDS to now be Distributive, since the name of the company has changed since the last time the document was updated.

ALSO added a new rule, per a request from Wes to show linter errors if the author doesn't use the strict mode directive. 

This MR should also potentially update the package version (semver, new version 2.0.0?)