### PR TITLE
1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@distributive/eslint-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@distributive/eslint-config",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "engines": {
         "node": ">=16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distributive/eslint-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "The shareable ESLint configuration used at Distributive when contributing to the Distributive Compute Protocol (DCP).",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Bump version number, switch namespace to `@distributive`, fingers crossed this will trigger a Release with Provenance