### PR TITLE
build(npm): update min node version to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.4",
       "license": "MIT",
       "engines": {
-        "node": ">=16",
+        "node": ">=18",
         "npm": ">=7"
       },
       "peerDependencies": {
-        "eslint": ">=8",
-        "eslint-plugin-distributive": "github:Distributive-Network/eslint-plugin-distributive"
+        "@distributive/eslint-plugin": "^1.0.0",
+        "eslint": ">=8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -24,6 +24,21 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@distributive/eslint-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@distributive/eslint-plugin/-/eslint-plugin-1.0.0.tgz",
+      "integrity": "sha512-lU8c92mcVQcUGYDuS7RRZyhXWHJq0Gt3SiJUwp4PPzZ7rnM0+avejWlT+1ELYLu/L8z6LgrlH9qmbS0P8/wdrQ==",
+      "peer": true,
+      "dependencies": {
+        "requireindex": "^1.2.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -398,21 +413,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-distributive": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Distributive-Network/eslint-plugin-distributive.git#7582884b5a51348282264904118d9dbfd3e1853d",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "requireindex": "^1.2.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": ">=8"
   },
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=7"
   },
   "publishConfig": {


### PR DESCRIPTION
To address the EOL for security updates of Node 16 on 2023-09-11.

Commands ran to update the `package*.json` files:

```console
npm pkg set engines.node='>=18'
npm install --package-lock-only
```

Refs: https://nodejs.dev/en/about/releases/